### PR TITLE
Correctly decode query component

### DIFF
--- a/src/Faithlife.OAuth/OAuthUtility.cs
+++ b/src/Faithlife.OAuth/OAuthUtility.cs
@@ -272,7 +272,7 @@ namespace Faithlife.OAuth
 			return query.Substring(1)
 				.Split('&')
 				.Select(str => str.Split(new[] { '=' }, 2))
-				.Select(x => new KeyValuePair<string, string>(UrlEncoding.Decode(x[0]), x.Length == 1 ? "" : UrlEncoding.Decode(x[1])));
+				.Select(x => new KeyValuePair<string, string>(UrlEncoding.Decode(x[0], UrlEncodingSettings.HttpUtilitySettings), x.Length == 1 ? "" : UrlEncoding.Decode(x[1], UrlEncodingSettings.HttpUtilitySettings)));
 		}
 
 		private static bool IsUnreserved(byte value)

--- a/tests/Faithlife.OAuth.Tests/OAuthUtilityTests.cs
+++ b/tests/Faithlife.OAuth.Tests/OAuthUtilityTests.cs
@@ -86,6 +86,7 @@ namespace Faithlife.OAuth.Tests
 		[TestCase("?659347508784", "659347508784", "")]
 		[TestCase("?q=%25%26%3D&a=b&s=%22123%22", "q", "%&=", "a", "b", "s", "\"123\"")]
 		[TestCase("?b5=%3D%253D&a3=a&c%40=&a2=r%20b", "b5", "=%3D", "a3", "a", "c@", "", "a2", "r b", Description = "From https://tools.ietf.org/html/rfc5849#section-3.4.1.3.1")]
+		[TestCase("?c2&a3=2+q", "c2", "", "a3", "2 q", Description = "From POST body in https://tools.ietf.org/html/rfc5849#section-3.4.1.3.1")]
 		[TestCase("")]
 		[TestCase("?")]
 		[TestCase(null)]


### PR DESCRIPTION
According to https://tools.ietf.org/html/rfc5849#section-3.4.1.3.1:

> The query component of the HTTP request URI as defined by [RFC3986],
> Section 3.4.  The query component is parsed into a list of name/value
> pairs by treating it as an "application/x-www-form-urlencoded" string,
> separating the names and values and decoding them as defined by
> [W3C.REC-html40-19980424], Section 17.13.4.

From https://www.w3.org/TR/1998/REC-html40-19980424/interact/forms.html#h-17.13.4.1:

> Space characters are replaced by `+'

Thus, a literal `+` sign in a URI query string should be treated as an encoded space before normalizing parameters.